### PR TITLE
Bump version and make it compatible with MagicCastle 13.1.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -2,6 +2,12 @@
 
 forge "https://forgeapi.puppetlabs.com"
 
-mod 'puppet-selinux', '3.2.0'
-mod 'puppetlabs-kubernetes', '6.0.0'
-mod 'puppetlabs-helm', '3.1.0'
+mod 'puppet-selinux', '3.4.1'
+mod 'puppetlabs-kubernetes', '8.0.0'
+mod 'puppetlabs-helm', '4.0.0'
+
+mod 'puppet-archive', '4.6.0'
+mod 'puppetlabs-stdlib', '6.6.0'
+mod 'puppet-augeasproviders_sysctl', '3.2.0'
+mod 'puppet-augeasproviders_core', '3.2.1'
+mod 'puppet-kmod', '3.2.0'

--- a/Puppetfile
+++ b/Puppetfile
@@ -5,9 +5,11 @@ forge "https://forgeapi.puppetlabs.com"
 mod 'puppet-selinux', '3.4.1'
 mod 'puppetlabs-kubernetes', '8.0.0'
 mod 'puppetlabs-helm', '4.0.0'
+mod 'puppetlabs-docker', '3.2.0'
 
 mod 'puppet-archive', '4.6.0'
 mod 'puppetlabs-stdlib', '6.6.0'
 mod 'puppet-augeasproviders_sysctl', '3.2.0'
 mod 'puppet-augeasproviders_core', '3.2.1'
 mod 'puppet-kmod', '3.2.0'
+

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,3 +14,6 @@ pushd data
 popd
 
 python3 bootstrap/merge_yaml.py
+
+# Clean up
+rm ./data/Centos.yaml

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,20 +1,9 @@
 #!/bin/bash
-cat << EOF > /etc/yum.repos.d/docker.repo
-[docker-ce-stable]
-name=Docker CE Stable - \$basearch
-baseurl=https://download.docker.com/linux/centos/\$releasever/\$basearch/stable
-enabled=1
-gpgcheck=1
-gpgkey=https://download.docker.com/linux/centos/gpg
-EOF
-
-yum -y install docker-ce
 yum -y install python36
 
-sed -i -e 's/disabled_plugins/#disabled_plugins/' /etc/containerd/config.toml
-systemctl restart containerd
-
-systemctl start docker && systemctl enable docker
+puppet apply /etc/puppetlabs/code/environments/main/manifests/site.pp  --tags mc_bootstrap
+puppet apply /etc/puppetlabs/code/environments/main/manifests/site.pp  --tags kubernetes::repos
+puppet apply /etc/puppetlabs/code/environments/main/manifests/site.pp  --tags kubernetes::packages
 
 k8s_version="1.28.0"
 controllers=$(python3 bootstrap/controllers.py)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,23 +1,14 @@
 #!/bin/bash
 yum -y install python36
 
-puppet apply /etc/puppetlabs/code/environments/main/manifests/site.pp  --tags mc_bootstrap
-puppet apply /etc/puppetlabs/code/environments/main/manifests/site.pp  --tags kubernetes::repos
-puppet apply /etc/puppetlabs/code/environments/main/manifests/site.pp  --tags kubernetes::packages
+curl -L https://github.com/cloudflare/cfssl/releases/download/v1.6.4/cfssl_1.6.4_linux_amd64 -o /usr/local/bin/cfssl
+curl -L https://github.com/cloudflare/cfssl/releases/download/v1.6.4/cfssljson_1.6.4_linux_amd64 -o /usr/local/bin/cfssljson
+chmod +x /usr/local/bin/cfssl /usr/local/bin/cfssljson
+/opt/puppetlabs/puppet/bin/gem install slop
 
-k8s_version="1.28.0"
 controllers=$(python3 bootstrap/controllers.py)
-kubetool_version=$(grep 'puppetlabs-kubernetes' Puppetfile| cut -d, -f2 | sed -e 's/^ //g' -e "s/'//g")
+export OS=centos
+export ETCD_INITIAL_CLUSTER=${controllers}
+/opt/puppetlabs/puppet/bin/ruby /etc/puppetlabs/code/environments/production/modules/kubernetes/tooling/kube_tool.rb
 
-docker run --rm -v $(pwd)/data:/mnt \
-    -e OS=centos\
-    -e VERSION=${k8s_version}\
-    -e CONTAINER_RUNTIME=docker\
-    -e CNI_PROVIDER=flannel\
-    -e ETCD_INITIAL_CLUSTER=${controllers}\
-    -e ETCD_IP="%{networking.ip}"\
-    -e KUBE_API_ADVERTISE_ADDRESS="%{networking.ip}"\
-    -e INSTALL_DASHBOARD=true\
-    puppet/kubetool:${kubetool_version}
-
-mv data/Centos.yaml data/k8s.yaml
+python3 bootstrap/merge_yaml.py

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -12,3 +12,4 @@ export ETCD_INITIAL_CLUSTER=${controllers}
 /opt/puppetlabs/puppet/bin/ruby /etc/puppetlabs/code/environments/production/modules/kubernetes/tooling/kube_tool.rb
 
 python3 bootstrap/merge_yaml.py
+cp *.yaml ./data

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,7 +9,8 @@ chmod +x /usr/local/bin/cfssl /usr/local/bin/cfssljson
 controllers=$(python3 bootstrap/controllers.py)
 export OS=centos
 export ETCD_INITIAL_CLUSTER=${controllers}
+pushd data
 /opt/puppetlabs/puppet/bin/ruby /etc/puppetlabs/code/environments/production/modules/kubernetes/tooling/kube_tool.rb
+popd
 
 python3 bootstrap/merge_yaml.py
-cp *.yaml ./data

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,20 +1,23 @@
 #!/bin/bash
 cat << EOF > /etc/yum.repos.d/docker.repo
-[docker]
-name=Docker repo
-baseurl=https://download.docker.com/linux/centos/7/x86_64/stable
-gpgkey=https://download.docker.com/linux/centos/gpg
+[docker-ce-stable]
+name=Docker CE Stable - \$basearch
+baseurl=https://download.docker.com/linux/centos/\$releasever/\$basearch/stable
 enabled=1
 gpgcheck=1
+gpgkey=https://download.docker.com/linux/centos/gpg
 EOF
 
 yum -y install docker-ce
-yum -y install PyYAML
+yum -y install python36
 
-systemctl start docker
+sed -i -e 's/disabled_plugins/#disabled_plugins/' /etc/containerd/config.toml
+systemctl restart containerd
 
-k8s_version="1.20.0"
-controllers=$(python bootstrap/controllers.py)
+systemctl start docker && systemctl enable docker
+
+k8s_version="1.28.0"
+controllers=$(python3 bootstrap/controllers.py)
 kubetool_version=$(grep 'puppetlabs-kubernetes' Puppetfile| cut -d, -f2 | sed -e 's/^ //g' -e "s/'//g")
 
 docker run --rm -v $(pwd)/data:/mnt \

--- a/bootstrap/controllers.py
+++ b/bootstrap/controllers.py
@@ -1,6 +1,10 @@
 #!/bin/python
 
-from yaml import load
+try:
+    from yaml import full_load as load
+except ImportError:
+    # Support old version of pyYaml
+    from yaml import load
 
 with open('data/terraform_data.yaml') as file:
     data = load(file)

--- a/bootstrap/merge_yaml.py
+++ b/bootstrap/merge_yaml.py
@@ -1,10 +1,15 @@
 import yaml
+try:
+    from yaml import full_load as load
+except ImportError:
+    # Support old version of pyYaml
+    from yaml import load
 
 with open('data/k8s_base.yaml') as f:
-    base = yaml.full_load(f)
+    base = load(f)
 
 with open('Centos.yaml') as f:
-    certificates = yaml.full_load(f)
+    certificates = load(f)
 
 for k, v in certificates.items():
     if k not in base.keys():

--- a/bootstrap/merge_yaml.py
+++ b/bootstrap/merge_yaml.py
@@ -8,7 +8,7 @@ except ImportError:
 with open('data/k8s_base.yaml') as f:
     base = load(f)
 
-with open('Centos.yaml') as f:
+with open('data/Centos.yaml') as f:
     certificates = load(f)
 
 for k, v in certificates.items():

--- a/bootstrap/merge_yaml.py
+++ b/bootstrap/merge_yaml.py
@@ -1,0 +1,14 @@
+import yaml
+
+with open('data/k8s_base.yaml') as f:
+    base = yaml.full_load(f)
+
+with open('Centos.yaml') as f:
+    certificates = yaml.full_load(f)
+
+for k, v in certificates.items():
+    if k not in base.keys():
+        base[k] = v
+
+with open('data/k8s.yaml', 'w') as f:
+    yaml.dump(base, f)

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,5 +1,9 @@
 ---
 helm::version: 2.17.0
 kubernetes::docker_package_name: docker-ce
-kubernetes::docker_version: 20.10.6-3.el7
+kubernetes::docker_version: 24.0.7-1.el8
+kubernetes::containerd_version: 1.6.25
+kubernetes::docker_storage_opts: []
 kubernetes::disable_swap: true
+kubernetes::etcd_version: 3.4.28
+kubernetes::docker_yum_baseurl: "https://download.docker.com/linux/centos/$releasever/x86_64/stable"

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,9 +1,9 @@
 ---
 helm::version: 2.17.0
-kubernetes::docker_package_name: docker-ce
-kubernetes::docker_version: 24.0.7-1.el8
-kubernetes::containerd_version: 1.6.25
+docker::version: 24.0.7
+
+kubernetes::manage_docker: false
+
 kubernetes::docker_storage_opts: []
 kubernetes::disable_swap: true
 kubernetes::etcd_version: 3.4.28
-kubernetes::docker_yum_baseurl: "https://download.docker.com/linux/centos/$releasever/x86_64/stable"

--- a/data/k8s_base.yaml
+++ b/data/k8s_base.yaml
@@ -1,0 +1,12 @@
+kubernetes::kubernetes_version: 1.28.0
+kubernetes::kubernetes_package_version: "%{alias('kubernetes::kubernetes_version')}"
+kubernetes::container_runtime: docker
+kubernetes::cni_network_provider: https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
+kubernetes::cni_pod_cidr: 10.244.0.0/16
+kubernetes::cni_provider: flannel
+kubernetes::etcd_ip: "%{networking.ip}"
+kubernetes::kube_api_advertise_address: "%{networking.ip}"
+kubernetes::install_dashboard: true
+
+kubernetes::etcd_peers: "%{alias('terraform.tag_ip.controller')}"
+kubernetes::controller_address: "%{lookup('terraform.tag_ip.controller.0')}:6443"

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -15,9 +15,22 @@ $host_template = @(END)
 <% end -%>
 END
 
+$config_containerd = @(END)
+disabled_plugins = []
+END
+
   file { '/etc/hosts':
     ensure  => file,
     content => inline_template($host_template)
+  }
+
+  file { '/etc/containerd':
+    ensure => 'directory',
+  }
+
+  file { '/etc/containerd/config.toml':
+    ensure  => file,
+    content => inline_template($config_containerd)
   }
 
   if 'controller' in $tags {

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -38,21 +38,8 @@ END
     content => inline_template($host_template)
   }
 
-  $api_server_count = size(lookup('terraform.tag_ip.controller'))
-
-  $filteredControllers = $instances.filter |$name, $info| {
-    'controller' in $info['tags']
-  }
-  $controllersIps = $filteredControllers.map |$name, $info| {
-    "${name}:${info['local_ip']}"
-  }
-
-  $etcd_initial_cluster = $controllersIps.join(',')
-
   if 'controller' in $tags {
     class { 'kubernetes':
-      api_server_count => $api_server_count,
-      etcd_initial_cluster => $etcd_initial_cluster,
       controller => true,
       require    => [
         Class['selinux'],
@@ -61,8 +48,6 @@ END
     }
   } elsif 'worker' in $tags {
     class { 'kubernetes':
-      api_server_count => $api_server_count,
-      etcd_initial_cluster => $etcd_initial_cluster,
       worker  => true,
       require => [
         Class['selinux'],

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -15,22 +15,25 @@ $host_template = @(END)
 <% end -%>
 END
 
-$config_containerd = @(END)
-disabled_plugins = []
-END
-
   file { '/etc/hosts':
     ensure  => file,
     content => inline_template($host_template)
   }
 
+$config_containerd = @(END)
+disabled_plugins = []
+END
+
   file { '/etc/containerd':
     ensure => 'directory',
+    tag    => 'mc_bootstrap',
   }
 
   file { '/etc/containerd/config.toml':
     ensure  => file,
-    content => inline_template($config_containerd)
+    content => inline_template($config_containerd),
+    require => File['/etc/containerd'],
+    tag    => 'mc_bootstrap',
   }
 
   if 'controller' in $tags {


### PR DESCRIPTION
Update the repo to make it work with the most recent version version of magic castle.

I used this tf config and I only tested it on AWS:
```
terraform {
  required_version = ">= 1.4.0"
}

module "aws" {
  source         = "git::https://github.com/ComputeCanada/magic_castle.git//aws"
  config_git_url = "https://github.com/etiennedub/k8s-environment.git"
  config_version = "update-version"

  cluster_name = "test-k8s"
  domain       = "computecanada.dev"
  image        = "ami-09ada793eea1559e6"

  instances = {
    master   = { type = "t3.large", tags = ["controller", "puppet", "public", "login"], count = 1 }
    replica  = { type = "t3.medium", tags = ["controller"], count = 1 }
    node     = { type = "t3.medium", tags = ["worker"], count = 1 }
  }

  volumes = {
    nfs = {
      home     = { size = 10, type = "gp2" }
      project  = { size = 50, type = "gp2" }
      scratch  = { size = 50, type = "gp2" }
    }
  }

  public_keys = [file("./key.pub")]
  generate_ssh_key = true
  region            = "ca-central-1"
}

output "public_ip" {
  value = module.aws.public_ip
}
```


